### PR TITLE
Clarify sender ids and timeline command docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -130,7 +130,7 @@ Before running the first command, set at least:
 ```dotenv
 CYBERBOSS_USER_NAME=YourName
 CYBERBOSS_USER_GENDER=female
-CYBERBOSS_ALLOWED_USER_IDS=your_wechat_user_id
+CYBERBOSS_ALLOWED_USER_IDS=bridge_observed_sender_id
 CYBERBOSS_WORKSPACE_ROOT=/absolute/path/to/your/project
 ```
 
@@ -139,6 +139,7 @@ Common optional variables:
 ```dotenv
 CYBERBOSS_ACCOUNT_ID=
 CYBERBOSS_CODEX_ENDPOINT=ws://127.0.0.1:8765
+CYBERBOSS_TIMEZONE=America/New_York
 CYBERBOSS_WEIXIN_ADAPTER=v2
 ```
 
@@ -147,9 +148,16 @@ Why this matters:
 - the first `cyberboss` command auto-generates `~/.cyberboss/weixin-instructions.md`
 - if `CYBERBOSS_USER_NAME` and `CYBERBOSS_USER_GENDER` are missing, that generated persona file may start from the wrong assumptions
 
+Meaning of these fields:
+
+- `CYBERBOSS_USER_NAME` is how Cyberboss addresses you in chat. It is a display/persona field, not a routing id.
+- `CYBERBOSS_ALLOWED_USER_IDS` must contain the exact sender ids observed by the WeChat bridge. Use the value exactly as stored in `~/.cyberboss/accounts/*.context-tokens.json` or `~/.cyberboss/sessions.json`. Do not put a nickname, display name, or a guessed WeChat handle here.
+
 If you want the strongest "push" effect, do not immediately rewrite the persona template by hand. Let the agent develop its rhythm through real conversation first, then edit only the parts that are clearly wrong.
 
 If you plan to use shared mode, set `CYBERBOSS_WORKSPACE_ROOT` before the first start so `shared:open` resolves the right thread for the right project.
+
+`CYBERBOSS_TIMEZONE` is optional. If you leave it unset, Cyberboss uses your system timezone. Timeline day validation and diary timestamps should follow that timezone. Existing timeline state created under the old default timezone is auto-synced the next time you run a timeline command.
 
 ### Terminal commands for end users
 
@@ -275,16 +283,23 @@ The following commands are primarily for agents and automations, not the main da
 
 ### Common agent commands
 
+- `npm run timeline:categories`
+  Print the current taxonomy and eventNodes; use this first if `categoryId`, `subcategoryId`, or `eventNodeId` is unclear
 - `npm run reminder:write -- --delay 30m --text "Reminder text"`
   Write a reminder for the future self
 - `npm run reminder:write -- --at "2026-04-07 21:30" --text "Reminder text"`
   Write a reminder at an explicit time
+  This command requires the selected sender id to already have a known `context_token`; if not, it should fail instead of guessing another sender
 - `npm run diary:write -- --title Title --text "Content"`
   Write a local diary entry
 - `npm run diary:write -- --date 2026-04-06 --title "4.6" --text "Content"`
   Write a diary entry into a specific date file
-- `npm run timeline:write -- --date YYYY-MM-DD --stdin`
-  Incrementally write timeline events
+- `npm run timeline:write -- --date YYYY-MM-DD --json '{"events":[...]}'
+  Incrementally write timeline events; if you use `--stdin`, pass a full JSON object like `{"events":[...]}`, not a raw array
+  Each event must include valid `startAt` and `endAt` absolute timestamps such as `2026-04-10T09:00:00+08:00`, with `endAt > startAt`, and both timestamps must fall on the same calendar day as `--date`
+  Each event must also include either `eventNodeId`, or `subcategoryId` with a resolvable category; explicitly passing both `categoryId` and `subcategoryId` is the safest form
+  If classification ids are unclear, run `npm run timeline:categories` first
+  Example: `npm run timeline:write -- --date 2026-04-10 --json '{"events":[{"id":"evt_1","startAt":"2026-04-10T09:00:00+08:00","endAt":"2026-04-10T09:30:00+08:00","title":"Breakfast","categoryId":"life","subcategoryId":"life.daily"}]}'`
 - `npm run timeline:build`
   Build the static timeline site
 - `npm run timeline:serve`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Before running the first command, set at least:
 ```dotenv
 CYBERBOSS_USER_NAME=YourName
 CYBERBOSS_USER_GENDER=female
-CYBERBOSS_ALLOWED_USER_IDS=your_wechat_user_id
+CYBERBOSS_ALLOWED_USER_IDS=bridge_observed_sender_id
 CYBERBOSS_WORKSPACE_ROOT=/absolute/path/to/your/project
 ```
 
@@ -138,6 +138,7 @@ Common optional variables:
 ```dotenv
 CYBERBOSS_ACCOUNT_ID=
 CYBERBOSS_CODEX_ENDPOINT=ws://127.0.0.1:8765
+CYBERBOSS_TIMEZONE=America/New_York
 CYBERBOSS_WEIXIN_ADAPTER=v2
 ```
 
@@ -146,9 +147,16 @@ Why this matters:
 - the first `cyberboss` command auto-generates `~/.cyberboss/weixin-instructions.md`
 - if `CYBERBOSS_USER_NAME` and `CYBERBOSS_USER_GENDER` are missing, that generated persona file may start from the wrong assumptions
 
+Meaning of these fields:
+
+- `CYBERBOSS_USER_NAME` is how Cyberboss addresses you in chat. It is a display/persona field, not a routing id.
+- `CYBERBOSS_ALLOWED_USER_IDS` must contain the exact sender ids observed by the WeChat bridge. The easiest way to get the correct user id is to run `npm run accounts` and use the id shown there. Do not put a nickname, display name, or guessed WeChat handle.
+
 If you want the strongest "push" effect, do not immediately rewrite the persona template by hand. Let the agent develop its rhythm through real conversation first, then edit only the parts that are clearly wrong.
 
 If you plan to use shared mode, set `CYBERBOSS_WORKSPACE_ROOT` before the first start so `shared:open` resolves the right thread for the right project.
+
+`CYBERBOSS_TIMEZONE` is optional. If you leave it unset, Cyberboss uses your system timezone. Timeline day validation and diary timestamps should follow that timezone. Existing timeline state created under the old default timezone is auto-synced the next time you run a timeline command.
 
 ### Terminal commands for end users
 
@@ -274,16 +282,23 @@ The following commands are primarily for agents and automations, not the main da
 
 ### Common agent commands
 
+- `npm run timeline:categories`
+  Print the current taxonomy and eventNodes; use this first if `categoryId`, `subcategoryId`, or `eventNodeId` is unclear
 - `npm run reminder:write -- --delay 30m --text "Reminder text"`
   Write a reminder for the future self
 - `npm run reminder:write -- --at "2026-04-07 21:30" --text "Reminder text"`
   Write a reminder at an explicit time
+  This command requires the selected sender id to already have a known `context_token`; if not, it should fail instead of guessing another sender
 - `npm run diary:write -- --title Title --text "Content"`
   Write a local diary entry
 - `npm run diary:write -- --date 2026-04-06 --title "4.6" --text "Content"`
   Write a diary entry into a specific date file
-- `npm run timeline:write -- --date YYYY-MM-DD --stdin`
-  Incrementally write timeline events
+- `npm run timeline:write -- --date YYYY-MM-DD --json '{"events":[...]}'
+  Incrementally write timeline events; if you use `--stdin`, pass a full JSON object like `{"events":[...]}`, not a raw array
+  Each event must include valid `startAt` and `endAt` absolute timestamps such as `2026-04-10T09:00:00+08:00`, with `endAt > startAt`, and both timestamps must fall on the same calendar day as `--date`
+  Each event must also include either `eventNodeId`, or `subcategoryId` with a resolvable category; explicitly passing both `categoryId` and `subcategoryId` is the safest form
+  If classification ids are unclear, run `npm run timeline:categories` first
+  Example: `npm run timeline:write -- --date 2026-04-10 --json '{"events":[{"id":"evt_1","startAt":"2026-04-10T09:00:00+08:00","endAt":"2026-04-10T09:30:00+08:00","title":"Breakfast","categoryId":"life","subcategoryId":"life.daily"}]}'`
 - `npm run timeline:build`
   Build the static timeline site
 - `npm run timeline:serve`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,7 +133,7 @@ npm install
 ```dotenv
 CYBERBOSS_USER_NAME=你的名字
 CYBERBOSS_USER_GENDER=female
-CYBERBOSS_ALLOWED_USER_IDS=你的微信 user id
+CYBERBOSS_ALLOWED_USER_IDS=桥实际看到的 sender id
 CYBERBOSS_WORKSPACE_ROOT=/绝对路径/你的项目目录
 ```
 
@@ -142,19 +142,27 @@ CYBERBOSS_WORKSPACE_ROOT=/绝对路径/你的项目目录
 ```dotenv
 CYBERBOSS_ACCOUNT_ID=
 CYBERBOSS_CODEX_ENDPOINT=ws://127.0.0.1:8765
+CYBERBOSS_TIMEZONE=America/New_York
 CYBERBOSS_WEIXIN_ADAPTER=v2
 ```
 
-`CYBERBOSS_ALLOWED_USER_IDS` 支持逗号分隔多个 user id。
+`CYBERBOSS_ALLOWED_USER_IDS` 支持逗号分隔多个 sender id。
 
 原因有两个：
 
 - 第一次运行任意 `cyberboss` 命令时，会自动生成 `~/.cyberboss/weixin-instructions.md`
 - 如果你没先设置 `CYBERBOSS_USER_NAME` 和 `CYBERBOSS_USER_GENDER`，生成出来的 instructions 可能不符合真实情况
 
+这两个字段的含义：
+
+- `CYBERBOSS_USER_NAME` 是 agent 在聊天里怎么称呼你。它是显示/人设字段，不参与消息路由。
+- `CYBERBOSS_ALLOWED_USER_IDS` 必须填写微信桥实际观测到的 sender id。最简单的做法是运行 `npm run accounts`，使用其中列出的 id。不要填昵称、显示名，或你自己猜的微信号。
+
 另外，如果你想要更强的“push 感”，建议一开始先不要主动大改 instructions 模板。先让 agent 在真实交流里自己更新行为，再回头只修明显不对的部分。
 
 如果你要跑共享线程，建议也在第一次启动前就把 `CYBERBOSS_WORKSPACE_ROOT` 配好。这样 `shared:open` 会优先接到你当前项目对应的那条线程，而不是回退到别的历史绑定。
+
+`CYBERBOSS_TIMEZONE` 是可选项。不设时，Cyberboss 默认使用系统时区。timeline 的日期校验和 diary 时间戳都会跟这个时区走；如果本地 timeline state 还是旧的默认时区，下一次执行 timeline 命令时会自动同步过去。
 
 ### 用户自己会用到的终端命令
 
@@ -282,16 +290,23 @@ ${HOME}/.cyberboss
 
 ### Agent 常用命令
 
+- `npm run timeline:categories`
+  打印当前 taxonomy 和 eventNode；如果不确定 `categoryId`、`subcategoryId` 或 `eventNodeId`，先跑这个
 - `npm run reminder:write -- --delay 30m --text "提醒内容"`
   给未来的自己留 reminder
 - `npm run reminder:write -- --at "2026-04-07 21:30" --text "提醒内容"`
   写明确时间点 reminder
+  这个命令要求当前选中的 sender id 已经有可用的 `context_token`；如果没有，就应该直接失败，不要猜另一个 sender
 - `npm run diary:write -- --title 标题 --text "内容"`
   写本地日记
 - `npm run diary:write -- --date 2026-04-06 --title "4.6" --text "内容"`
   写指定日期日记
-- `npm run timeline:write -- --date YYYY-MM-DD --stdin`
-  增量写入时间轴
+- `npm run timeline:write -- --date YYYY-MM-DD --json '{"events":[...]}'
+  增量写入时间轴；如果用 `--stdin`，传完整 JSON 对象 `{"events":[...]}`，不要传裸数组
+  每条事件都必须带合法的 `startAt` 和 `endAt` 绝对时间戳，例如 `2026-04-10T09:00:00+08:00`；同时要求 `endAt > startAt`，而且两个时间都必须落在 `--date` 对应的那一天内
+  每条事件还必须提供 `eventNodeId`，或者提供能推导分类的 `subcategoryId`；最稳妥的写法是显式同时传 `categoryId` 和 `subcategoryId`
+  如果分类 id 不确定，先执行 `npm run timeline:categories`
+  示例：`npm run timeline:write -- --date 2026-04-10 --json '{"events":[{"id":"evt_1","startAt":"2026-04-10T09:00:00+08:00","endAt":"2026-04-10T09:30:00+08:00","title":"早餐","categoryId":"life","subcategoryId":"life.daily"}]}'`
 - `npm run timeline:build`
   构建时间轴静态页面
 - `npm run timeline:serve`

--- a/src/core/command-registry.js
+++ b/src/core/command-registry.js
@@ -375,6 +375,8 @@ function buildTopicUsage(topic) {
         "  --at 2026-04-07T21:30+08:00 | 2026-04-07 21:30",
         "  --text \"提醒内容\"",
         "  --user <wechatUserId>  可选",
+        "",
+        "当前选中的 sender id 必须已经有可用的 context_token；否则命令会直接失败。",
       ].join("\n");
     case "diary":
       return [


### PR DESCRIPTION
## Summary
- clarify that CYBERBOSS_USER_NAME is a display/persona field
- clarify that CYBERBOSS_ALLOWED_USER_IDS must use the exact bridge-observed sender id
- refresh README examples for timezone and timeline write usage
- clarify reminder help text for the selected sender id and context_token requirement

## Scope
This PR is docs-only. It does not change runtime behavior, sender selection logic, reminder delivery logic, or env auto-population.

## How This Was Caught
This came up during a real reminder failure. CYBERBOSS_ALLOWED_USER_IDS had been manually set from the README example using a human-understood WeChat id, but the bridge had actually persisted context_token data under a different bridge-observed sender id. As a result, reminder:write failed with a missing context_token error even though messages had already been sent through the same bridge. That showed the docs were too ambiguous about what kind of id CYBERBOSS_ALLOWED_USER_IDS needs.

## Notes
- the sender id guidance now points users at the persisted bridge state instead of nicknames or guessed WeChat handles
- the timeline examples now document timeline:categories, --json, timestamp requirements, and classification requirements
