### PR TITLE
fix: recover trailing JSON actions in Codex check-ins

### DIFF
--- a/src/core/stream-delivery.js
+++ b/src/core/stream-delivery.js
@@ -728,6 +728,10 @@ function resolveSystemReplyDelivery(replyText, policy = createSystemReplyPolicy(
   }
 
   const source = normalizeSystemReplySource(normalized);
+  const actionCandidate = extractSystemActionJsonCandidate(source.text);
+  if (actionCandidate) {
+    return resolveSystemReplyAction(actionCandidate);
+  }
   if (source.requiresStructuredAction || source.text.startsWith("{")) {
     return resolveSystemReplyAction(source.text);
   }

--- a/test/stream-delivery.test.js
+++ b/test/stream-delivery.test.js
@@ -126,6 +126,44 @@ test("system send_message JSON may be wrapped in a json fence", async () => {
   }]);
 });
 
+test("codex system reply accepts trailing send_message JSON after plain text prefix", async () => {
+  const { sent, streamDelivery } = createHarness({ runtimeId: "codex" });
+  streamDelivery.queueReplyTargetForThread("thread-2p", {
+    userId: "user-2p",
+    contextToken: "ctx-2p",
+    provider: "system",
+  });
+
+  await runCompletedTurnWithResultOnly(streamDelivery, {
+    threadId: "thread-2p",
+    turnId: "turn-2p",
+    text: "I will note the user's current status first.\n\n{\"action\":\"send_message\",\"message\":\"still deploying?\"}",
+  });
+
+  assert.deepEqual(sent, [{
+    userId: "user-2p",
+    text: "still deploying?",
+    contextToken: "ctx-2p",
+  }]);
+});
+
+test("codex system reply rejects trailing plain text after JSON action", async () => {
+  const { sent, streamDelivery } = createHarness({ runtimeId: "codex" });
+  streamDelivery.queueReplyTargetForThread("thread-2q", {
+    userId: "user-2q",
+    contextToken: "ctx-2q",
+    provider: "system",
+  });
+
+  await runCompletedTurnWithResultOnly(streamDelivery, {
+    threadId: "thread-2q",
+    turnId: "turn-2q",
+    text: "{\"action\":\"send_message\",\"message\":\"still deploying?\"}\n\nextra trailing text",
+  });
+
+  assert.deepEqual(sent, []);
+});
+
 test("codex system reply rejects plain text", async () => {
   const { sent, streamDelivery } = createHarness({ runtimeId: "codex" });
   streamDelivery.queueReplyTargetForThread("thread-2c", {


### PR DESCRIPTION
老师您好，感谢您的项目，对我帮助很大，然后我在使用中发现了一处，也许能让项目更棒的点

## 具体问题说明

在定时 check-in 场景中，Codex 有时会在合法的系统动作 JSON 前面加一段说明文字，例如：

```text
我先记一下你今晚还在部署这条线，过会儿再看看有没有卡住。

{"action":"send_message","message":"还在部署吗？卡住了就把报错丢给我，别自己熬着啃。"}
```


当前系统回复解析器会尝试把整段内容作为一个 JSON 对象解析，因此会报错：

```text
invalid system reply
reason=final reply is not a JSON object
```

结果是 check-in 已经成功生成，但在发送到微信之前被丢弃。

## 修改内容

本次修改复用了现有的 `extractSystemActionJsonCandidate()`，当回复末尾存在合法的结构化 action JSON 时，先提取该 JSON，再按原有逻辑解析。

## 行为边界

* 支持“前置普通文字 + 末尾合法 `send_message` 或 `silent` JSON”
* 不放开 Codex 的普通文本系统回复
* JSON 后面仍有额外文字时继续拒绝
* 原有纯 JSON、`json:` 前缀和 JSON 代码块行为保持不变

## 测试

* 新增“前置文字 + 末尾合法 JSON”测试
* 新增“JSON 后有额外文字时拒绝”测试
* `npm run check` 通过
* `node --test test/stream-delivery.test.js` 通过，19/19
* 全量测试中有 9 个与本次修改无关的 Windows 环境兼容性失败
